### PR TITLE
Publish is broken when dependencies contain a slash

### DIFF
--- a/.ci/writeBuildInformation.sh
+++ b/.ci/writeBuildInformation.sh
@@ -26,6 +26,8 @@ if [ "$DEPENDENCIES" = "null" ]; then
     DEPENDENCIES="{}"
 fi
 
+DEPENDENCIES="${DEPENDENCIES//[\/]/\\/}" # replace '/' with '\/' because it's a special char
+
 DATE=$(date -u --iso-8601=seconds)
 
 echo "Writing the following properties into $TARGET_FILE"


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
