### PR TITLE
Refactor/remove serialization for derived key handles, remove keySpec property

### DIFF
--- a/src/CryptoErrorCode.ts
+++ b/src/CryptoErrorCode.ts
@@ -58,6 +58,7 @@ export enum CryptoErrorCode {
     CalProvidersAlreadyInitialized = "error.crypto.cal.providersAlreadyInitialized",
     CalImportOfKey = "error.crypto.cal.calImportOfKey",
     CalKeyDerivation = "error.crypto.cal.keyDerivation",
+    CalLoadKey = "error.crypto.cal.loadKey",
 
     DeserializeValidation = "error.deserialize.validation"
 }

--- a/src/crypto-layer/CryptoDerivationHandle.ts
+++ b/src/crypto-layer/CryptoDerivationHandle.ts
@@ -9,7 +9,8 @@ import { CryptoEncryptionAlgorithm } from "../encryption/CryptoEncryption";
 import { CryptoHashAlgorithm } from "../hash/CryptoHash";
 import { getProvider, ProviderIdentifier } from "./CryptoLayerProviders";
 import { CryptoLayerUtils } from "./CryptoLayerUtils";
-import { BaseKeyHandle, BaseKeyHandleConstructor } from "./encryption/BaseKeyHandle";
+import { BaseKeyHandle } from "./encryption/BaseKeyHandle";
+import { DerivedBaseKeyHandle, DerivedBaseKeyHandleConstructor } from "./encryption/DerivedBaseKeyHandle";
 import { DeviceBoundDerivedKeyHandle } from "./encryption/DeviceBoundDerivedKeyHandle";
 import { DeviceBoundKeyHandle } from "./encryption/DeviceBoundKeyHandle";
 import { PortableDerivedKeyHandle } from "./encryption/PortableDerivedKeyHandle";
@@ -28,8 +29,8 @@ export interface DeriveKeyHandleFromPasswordParameters {
 }
 
 export class CryptoDerivationHandle {
-    private static async deriveKeyHandleFromPassword<T extends BaseKeyHandle>(
-        constructor: BaseKeyHandleConstructor<T>,
+    private static async deriveKeyHandleFromPassword<T extends DerivedBaseKeyHandle>(
+        constructor: DerivedBaseKeyHandleConstructor<T>,
         derivationParameters: DeriveKeyHandleFromPasswordParameters,
         keySpecOfResultingKey: KeySpec
     ): Promise<T> {
@@ -105,8 +106,8 @@ export class CryptoDerivationHandle {
         );
     }
 
-    private static async deriveKeyFromBaseKeyHandle<T extends BaseKeyHandle, R extends BaseKeyHandle>(
-        constructor: BaseKeyHandleConstructor<R>,
+    private static async deriveKeyFromBaseKeyHandle<T extends BaseKeyHandle, R extends DerivedBaseKeyHandle>(
+        constructor: DerivedBaseKeyHandleConstructor<R>,
         baseKey: T,
         keyId: number,
         context: string

--- a/src/crypto-layer/encryption/BaseKeyHandle.ts
+++ b/src/crypto-layer/encryption/BaseKeyHandle.ts
@@ -1,11 +1,11 @@
 import { ISerializable, ISerialized, SerializableAsync, serialize, type, validate } from "@js-soft/ts-serval";
 import { KeyHandle, KeySpec, Provider } from "@nmshd/rs-crypto-types";
-import { CryptoHashAlgorithm } from "src/hash/CryptoHash";
 import { CoreBuffer, ICoreBuffer } from "../../CoreBuffer";
 import { CryptoError } from "../../CryptoError";
 import { CryptoErrorCode } from "../../CryptoErrorCode";
 import { CryptoSerializableAsync } from "../../CryptoSerializable";
 import { CryptoEncryptionAlgorithm } from "../../encryption/CryptoEncryption";
+import { CryptoHashAlgorithm } from "../../hash/CryptoHash";
 import { getProvider, ProviderIdentifier } from "../CryptoLayerProviders";
 import { CryptoLayerUtils } from "../CryptoLayerUtils";
 
@@ -19,15 +19,11 @@ export interface IBaseKeyHandle extends ISerializable {
     providerName: string;
 }
 
-export interface BaseKeyHandleConstructor<T extends BaseKeyHandle> {
+export interface BaseKeyHandleConstructor<T> {
     new (): T;
 
     deserialize(value: string): Promise<T>;
-    fromProviderAndKeyHandle(
-        provider: Provider,
-        keyHandle: KeyHandle,
-        other?: { providerName?: string; keyId?: string; keySpec?: KeySpec }
-    ): Promise<T>;
+    fromProviderAndKeyHandle(provider: Provider, keyHandle: KeyHandle): Promise<T>;
     fromAny(value: any): Promise<T>;
 }
 

--- a/src/crypto-layer/encryption/CryptoEncryptionHandle.ts
+++ b/src/crypto-layer/encryption/CryptoEncryptionHandle.ts
@@ -64,7 +64,7 @@ export class CryptoEncryptionHandle {
         secretKeyHandle: T,
         nonce?: CoreBuffer
     ): Promise<CryptoCipher> {
-        const encryptionAlgorithm = CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(secretKeyHandle.spec.cipher);
+        const encryptionAlgorithm = await secretKeyHandle.encryptionAlgorithm();
 
         if (nonce === undefined || nonce.buffer.length === 0) {
             nonce = await this.createNonce(encryptionAlgorithm, secretKeyHandle.provider);
@@ -98,7 +98,7 @@ export class CryptoEncryptionHandle {
         nonce: CoreBuffer,
         counter: number
     ): Promise<CryptoCipher> {
-        const encryptionAlgorithm = CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(secretKeyHandle.spec.cipher);
+        const encryptionAlgorithm = await secretKeyHandle.encryptionAlgorithm();
 
         CryptoValidation.checkCounter(counter);
         CryptoValidation.checkNonceForAlgorithm(nonce, encryptionAlgorithm);
@@ -130,7 +130,7 @@ export class CryptoEncryptionHandle {
         secretKeyHandle: T,
         nonce?: CoreBuffer
     ): Promise<CoreBuffer> {
-        const encryptionAlgorithm = CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(secretKeyHandle.spec.cipher);
+        const encryptionAlgorithm = await secretKeyHandle.encryptionAlgorithm();
 
         let publicNonce;
         if (nonce !== undefined) {
@@ -165,7 +165,7 @@ export class CryptoEncryptionHandle {
         nonce: CoreBuffer,
         counter: number
     ): Promise<CoreBuffer> {
-        const encryptionAlgorithm = CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(secretKeyHandle.spec.cipher);
+        const encryptionAlgorithm = await secretKeyHandle.encryptionAlgorithm();
 
         CryptoValidation.checkCounter(counter);
         CryptoValidation.checkNonceForAlgorithm(nonce, encryptionAlgorithm);
@@ -218,7 +218,7 @@ export class CryptoEncryptionHandle {
         portableKeyHandle: PortableKeyHandle | PortableDerivedKeyHandle
     ): Promise<CryptoSecretKey> {
         const rawKeyPromise = CryptoEncryptionHandle.extractRawKey(portableKeyHandle);
-        const algorithm = CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(portableKeyHandle.spec.cipher);
+        const algorithm = await portableKeyHandle.encryptionAlgorithm();
         const cryptoSecretKeyObj: ICryptoSecretKey = {
             algorithm: algorithm,
             secretKey: await rawKeyPromise

--- a/src/crypto-layer/encryption/CryptoEncryptionHandle.ts
+++ b/src/crypto-layer/encryption/CryptoEncryptionHandle.ts
@@ -11,6 +11,7 @@ import { CryptoHashAlgorithm } from "../../hash/CryptoHash";
 import { getProvider, ProviderIdentifier } from "../CryptoLayerProviders";
 import { CryptoLayerUtils } from "../CryptoLayerUtils";
 import { BaseKeyHandle, BaseKeyHandleConstructor } from "./BaseKeyHandle";
+import { DerivedBaseKeyHandle, DerivedBaseKeyHandleConstructor } from "./DerivedBaseKeyHandle";
 import { DeviceBoundKeyHandle } from "./DeviceBoundKeyHandle";
 import { PortableDerivedKeyHandle } from "./PortableDerivedKeyHandle";
 import { PortableKeyHandle } from "./PortableKeyHandle";
@@ -23,9 +24,7 @@ export class CryptoEncryptionHandle {
     ): Promise<T> {
         const provider = getProvider(providerIdent);
         const keyHandle = await provider.createKey(spec);
-        const secretKeyHandle = await constructor.fromProviderAndKeyHandle(provider, keyHandle, {
-            keySpec: spec
-        });
+        const secretKeyHandle = await constructor.fromProviderAndKeyHandle(provider, keyHandle);
         return secretKeyHandle;
     }
 
@@ -59,7 +58,7 @@ export class CryptoEncryptionHandle {
         return await this.generateKeyHandle<PortableKeyHandle>(PortableKeyHandle, providerIdent, portableSpec);
     }
 
-    public static async encrypt<T extends BaseKeyHandle>(
+    public static async encrypt<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
         plaintext: CoreBuffer,
         secretKeyHandle: T,
         nonce?: CoreBuffer
@@ -92,7 +91,7 @@ export class CryptoEncryptionHandle {
         });
     }
 
-    public static async encryptWithCounter<T extends BaseKeyHandle>(
+    public static async encryptWithCounter<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
         plaintext: CoreBuffer,
         secretKeyHandle: T,
         nonce: CoreBuffer,
@@ -125,7 +124,7 @@ export class CryptoEncryptionHandle {
         });
     }
 
-    public static async decrypt<T extends BaseKeyHandle>(
+    public static async decrypt<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
         cipher: CryptoCipher,
         secretKeyHandle: T,
         nonce?: CoreBuffer
@@ -159,7 +158,7 @@ export class CryptoEncryptionHandle {
         }
     }
 
-    public static async decryptWithCounter<T extends BaseKeyHandle>(
+    public static async decryptWithCounter<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
         cipher: CryptoCipher,
         secretKeyHandle: T,
         nonce: CoreBuffer,
@@ -226,8 +225,8 @@ export class CryptoEncryptionHandle {
         return CryptoSecretKey.from(cryptoSecretKeyObj);
     }
 
-    private static async keyHandleFromCryptoSecretKey<T extends BaseKeyHandle>(
-        constructor: BaseKeyHandleConstructor<T>,
+    private static async keyHandleFromCryptoSecretKey<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
+        constructor: DerivedBaseKeyHandleConstructor<T>,
         providerIdent: ProviderIdentifier,
         cryptoSecretKey: CryptoSecretKey,
         signingHash: CryptoHashAlgorithm,

--- a/src/crypto-layer/encryption/DerivedBaseKeyHandle.ts
+++ b/src/crypto-layer/encryption/DerivedBaseKeyHandle.ts
@@ -1,0 +1,88 @@
+// filepath: m:\DEV\WorkProjects\nmshd2\ts-crypto\src\crypto-layer\encryption\DerivedBaseKeyHandle.ts
+import { KeyHandle, KeySpec, Provider } from "@nmshd/rs-crypto-types";
+import { ICoreBuffer } from "../../CoreBuffer";
+import { CryptoError } from "../../CryptoError";
+import { CryptoErrorCode } from "../../CryptoErrorCode";
+import { CryptoEncryptionAlgorithm } from "../../encryption/CryptoEncryption"; // Path relative to src/crypto-layer/encryption/
+import { CryptoHashAlgorithm } from "../../hash/CryptoHash"; // Assuming 'src/' is a root path or alias
+import { getProvider, ProviderIdentifier } from "../CryptoLayerProviders";
+import { CryptoLayerUtils } from "../CryptoLayerUtils"; // Path relative to src/crypto-layer/encryption/
+
+export interface DerivedBaseKeyHandleConstructor<T> {
+    new (): T;
+
+    fromProviderAndKeyHandle(provider: Provider, keyHandle: KeyHandle): Promise<T>;
+}
+
+/**
+ * Variant of {@link BaseKeyHandle} without serialization and deserialization.
+ */
+export abstract class DerivedBaseKeyHandle {
+    public id: string;
+    public providerName: string;
+
+    public provider: Provider;
+    public keyHandle: KeyHandle;
+
+    public async encryptionAndHashAlgorithm(): Promise<[CryptoEncryptionAlgorithm, CryptoHashAlgorithm]> {
+        const spec = await this.keyHandle.spec();
+        return [
+            CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(spec.cipher),
+            CryptoLayerUtils.cryptoHashAlgorithmFromCryptoHash(spec.signing_hash)
+        ];
+    }
+
+    public async encryptionAlgorithm(): Promise<CryptoEncryptionAlgorithm> {
+        const spec = await this.keyHandle.spec();
+        return CryptoLayerUtils.cryptoEncryptionAlgorithmFromCipher(spec.cipher);
+    }
+
+    public async hashAlgorithm(): Promise<CryptoHashAlgorithm> {
+        const spec = await this.keyHandle.spec();
+        return CryptoLayerUtils.cryptoHashAlgorithmFromCryptoHash(spec.signing_hash);
+    }
+
+    /**
+     * Creates a new {@link DerivedBaseKeyHandle} or its child from an existing {@link KeyHandle}.
+     */
+    public static async fromProviderAndKeyHandle<T extends DerivedBaseKeyHandle>(
+        this: new () => T,
+        provider: Provider,
+        keyHandle: KeyHandle
+    ): Promise<T> {
+        const result = new this();
+
+        [result.providerName, result.id] = await Promise.all([provider.providerName(), keyHandle.id()]);
+
+        result.provider = provider;
+        result.keyHandle = keyHandle;
+        return result;
+    }
+}
+
+export abstract class ImportableDerivedBaseKeyHandle extends DerivedBaseKeyHandle {
+    /**
+     * Creates a new {@link BaseKeyHandle} or its child by importing a raw key into a provider.
+     */
+    public static async fromRawKey<T extends ImportableDerivedBaseKeyHandle>(
+        this: DerivedBaseKeyHandleConstructor<T>,
+        providerIdent: ProviderIdentifier,
+        rawKey: ICoreBuffer,
+        spec: KeySpec
+    ): Promise<T> {
+        const provider = getProvider(providerIdent);
+        let keyHandle;
+        try {
+            keyHandle = await provider.importKey(spec, rawKey.buffer);
+        } catch (e) {
+            throw new CryptoError(
+                CryptoErrorCode.CalImportOfKey,
+                "Failed to import raw symmetric key.",
+                undefined,
+                e as Error,
+                ImportableDerivedBaseKeyHandle.fromRawKey
+            );
+        }
+        return await this.fromProviderAndKeyHandle(provider, keyHandle);
+    }
+}

--- a/src/crypto-layer/encryption/DeviceBoundDerivedKeyHandle.ts
+++ b/src/crypto-layer/encryption/DeviceBoundDerivedKeyHandle.ts
@@ -1,22 +1,9 @@
 import { type } from "@js-soft/ts-serval";
-import { CoreBuffer } from "../../CoreBuffer";
-import { BaseKeyHandle, IBaseKeyHandleSerialized } from "./BaseKeyHandle";
+import { DerivedBaseKeyHandle } from "./DerivedBaseKeyHandle";
 
 /** Non exportable, ephemeral key handle that is derived from a device bound key handle. */
 @type("DeviceBoundDerivedKeyHandle")
-export class DeviceBoundDerivedKeyHandle extends BaseKeyHandle {
+export class DeviceBoundDerivedKeyHandle extends DerivedBaseKeyHandle {
     // Phantom marker to make this type incompatible to other types that extend `BaseKeyHandle`.
     public readonly _isDeviceBoundDerivedKeyHandle = true;
-
-    public override toJSON(verbose = true): IBaseKeyHandleSerialized {
-        return {
-            kid: this.id,
-            pnm: this.providerName,
-            "@type": verbose ? "DeviceBoundDerivedKeyHandle" : undefined
-        };
-    }
-
-    public override toBase64(verbose = true): string {
-        return CoreBuffer.utf8_base64(this.serialize(verbose));
-    }
 }

--- a/src/crypto-layer/encryption/DeviceBoundDerivedKeyHandle.ts
+++ b/src/crypto-layer/encryption/DeviceBoundDerivedKeyHandle.ts
@@ -12,7 +12,6 @@ export class DeviceBoundDerivedKeyHandle extends BaseKeyHandle {
         return {
             kid: this.id,
             pnm: this.providerName,
-            spc: this.spec,
             "@type": verbose ? "DeviceBoundDerivedKeyHandle" : undefined
         };
     }

--- a/src/crypto-layer/encryption/DeviceBoundKeyHandle.ts
+++ b/src/crypto-layer/encryption/DeviceBoundKeyHandle.ts
@@ -12,7 +12,6 @@ export class DeviceBoundKeyHandle extends BaseKeyHandle {
         return {
             kid: this.id,
             pnm: this.providerName,
-            spc: this.spec,
             "@type": verbose ? "DeviceBoundKeyHandle" : undefined
         };
     }

--- a/src/crypto-layer/encryption/PortableDerivedKeyHandle.ts
+++ b/src/crypto-layer/encryption/PortableDerivedKeyHandle.ts
@@ -11,7 +11,6 @@ export class PortableDerivedKeyHandle extends BaseKeyHandle {
         return {
             kid: this.id,
             pnm: this.providerName,
-            spc: this.spec,
             "@type": verbose ? "PortableDerivedKeyHandle" : undefined
         };
     }

--- a/src/crypto-layer/encryption/PortableDerivedKeyHandle.ts
+++ b/src/crypto-layer/encryption/PortableDerivedKeyHandle.ts
@@ -1,21 +1,8 @@
 import { type } from "@js-soft/ts-serval";
-import { CoreBuffer } from "../../CoreBuffer";
-import { BaseKeyHandle, IBaseKeyHandleSerialized } from "./BaseKeyHandle";
+import { ImportableDerivedBaseKeyHandle } from "./DerivedBaseKeyHandle";
 
 @type("PortableDerivedKeyHandle")
-export class PortableDerivedKeyHandle extends BaseKeyHandle {
+export class PortableDerivedKeyHandle extends ImportableDerivedBaseKeyHandle {
     // Phantom marker to make this type incompatible to other types that extend `BaseKeyHandle`.
     public readonly _isPortableDeriveKeyHandle = true;
-
-    public override toJSON(verbose = true): IBaseKeyHandleSerialized {
-        return {
-            kid: this.id,
-            pnm: this.providerName,
-            "@type": verbose ? "PortableDerivedKeyHandle" : undefined
-        };
-    }
-
-    public override toBase64(verbose = true): string {
-        return CoreBuffer.utf8_base64(this.serialize(verbose));
-    }
 }

--- a/src/crypto-layer/encryption/PortableKeyHandle.ts
+++ b/src/crypto-layer/encryption/PortableKeyHandle.ts
@@ -12,7 +12,6 @@ export class PortableKeyHandle extends ImportableBaseKeyHandle {
         return {
             kid: this.id,
             pnm: this.providerName,
-            spc: this.spec,
             "@type": verbose ? "PortableKeyHandle" : undefined
         };
     }

--- a/src/crypto-layer/index.ts
+++ b/src/crypto-layer/index.ts
@@ -4,6 +4,7 @@ export * from "./CryptoLayerProviders";
 export * from "./CryptoLayerUtils";
 export * from "./encryption/BaseKeyHandle";
 export * from "./encryption/CryptoEncryptionHandle";
+export * from "./encryption/DerivedBaseKeyHandle";
 export * from "./encryption/DeviceBoundDerivedKeyHandle";
 export * from "./encryption/DeviceBoundKeyHandle";
 export * from "./encryption/PortableDerivedKeyHandle";

--- a/test/cal/KeyValidation.ts
+++ b/test/cal/KeyValidation.ts
@@ -3,6 +3,7 @@ import {
     CoreBuffer,
     CryptoCipher,
     CryptoEncryptionHandle,
+    DerivedBaseKeyHandle,
     DeviceBoundDerivedKeyHandle,
     DeviceBoundKeyHandle,
     PortableDerivedKeyHandle,
@@ -14,7 +15,9 @@ import { expect } from "chai";
 /**
  * Tests SecretKeyHandle for validity and executes the id function.
  */
-export async function assertSecretKeyHandleValid<T extends BaseKeyHandle>(handle: T): Promise<void> {
+export async function assertSecretKeyHandleValid<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
+    handle: T
+): Promise<void> {
     expect(handle).to.exist;
     expect(handle.id).to.exist.and.to.be.a("string");
     expect(handle.keyHandle).to.exist;
@@ -44,7 +47,10 @@ export async function assertSecretKeyHandleValid<T extends BaseKeyHandle>(handle
     }
 }
 
-async function testDecryptEncryptIsIdentityFunction<T extends BaseKeyHandle>(before: T, after: T): Promise<void> {
+async function testDecryptEncryptIsIdentityFunction<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
+    before: T,
+    after: T
+): Promise<void> {
     const payload = CoreBuffer.fromUtf8("Hello World!");
 
     const encryptedPayload = await CryptoEncryptionHandle.encrypt(payload, before);
@@ -64,7 +70,10 @@ async function testDecryptEncryptIsIdentityFunction<T extends BaseKeyHandle>(bef
 /**
  * Test that the content of two SecretKeys match.
  */
-export async function assertSecretKeyHandleEqual<T extends BaseKeyHandle>(before: T, after: T): Promise<void> {
+export async function assertSecretKeyHandleEqual<T extends BaseKeyHandle | DerivedBaseKeyHandle>(
+    before: T,
+    after: T
+): Promise<void> {
     const [beforeSpec, afterSpec] = await Promise.all([before.keyHandle.spec(), after.keyHandle.spec()]);
     expect(beforeSpec).to.deep.equal(afterSpec);
     if (

--- a/test/cal/encryption/CryptoSecretKeyHandle.test.ts
+++ b/test/cal/encryption/CryptoSecretKeyHandle.test.ts
@@ -54,7 +54,6 @@ export class CryptoSecretKeyHandleTest {
 
                     const loadedKeyHandle = await DeviceBoundKeyHandle.from({
                         id: keyHandle.id,
-                        spec: keyHandle.spec,
                         providerName: keyHandle.providerName
                     });
 


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [ ] I labeled the PR.
- [ ] I self-reviewed the PR.

# Description

* Remove the `keySpec` property of `BaseKeyHandle` and derivatives, due to the property neither being used, nor `ts-serval` being able to skip certain verifications (`instanceof` with `@validate()`).
* Have `Derived` variants of of key handle not be able to serialize. A derived key handle is ephemeral. Deserializing such key handle is only possible if a provider stores an ephemeral key handle, or if the serialized representation stores the secret key. Neither is in the spirit of a key handle.
